### PR TITLE
allow running wiremock in HTTPS

### DIFF
--- a/charts/wiremock/templates/deployment.yaml
+++ b/charts/wiremock/templates/deployment.yaml
@@ -40,10 +40,12 @@ spec:
             httpGet:
               path: /__admin/webapp
               port: {{ .Values.service.internalPort }}
+              scheme: {{ .Values.scheme }}
           readinessProbe:
             httpGet:
               path: /__admin/webapp
               port: {{ .Values.service.internalPort }}
+              scheme: {{ .Values.scheme }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:

--- a/charts/wiremock/values.yaml
+++ b/charts/wiremock/values.yaml
@@ -56,3 +56,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+scheme: "HTTP"


### PR DESCRIPTION
With the following value overrides it will run successfully in HTTPS:

wiremock:
  scheme: "HTTPS"
  env: 
    WIREMOCK_OPTIONS: "--https-port=9021,--max-request-journal=1000,--local-response-templating,--root-dir=/home/wiremock/storage"